### PR TITLE
Assign to Underlying Type

### DIFF
--- a/encoder_test.go
+++ b/encoder_test.go
@@ -220,7 +220,7 @@ func TestEncoder_RegisterEncodeFunc(t *testing.T) {
 	}
 }
 
-//BenchmarkMarshal-4     	  295726	     11902 ns/op
+// BenchmarkMarshal-4     	  295726	     11902 ns/op
 func BenchmarkMarshal(b *testing.B) {
 	data := getMockData2()
 

--- a/parser.go
+++ b/parser.go
@@ -2,6 +2,7 @@ package urlquery
 
 import (
 	"bytes"
+	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -253,6 +254,8 @@ func (p *parser) parseValue(rv reflect.Value, parentNode string) {
 		rv.Set(v)
 	} else if v.CanConvert(targetType) {
 		rv.Set(v.Convert(targetType))
+	} else {
+		panic(fmt.Sprintf("parseValue: value of type %s is not assignable to type %s", srcType, targetType))
 	}
 }
 

--- a/parser.go
+++ b/parser.go
@@ -246,7 +246,14 @@ func (p *parser) parseValue(rv reflect.Value, parentNode string) {
 		return
 	}
 
-	rv.Set(v)
+	srcType := v.Type()
+	targetType := rv.Type()
+
+	if srcType.AssignableTo(targetType) {
+		rv.Set(v)
+	} else if v.CanConvert(targetType) {
+		rv.Set(v.Convert(targetType))
+	}
 }
 
 // parse text to specified-type value

--- a/parser_test.go
+++ b/parser_test.go
@@ -385,8 +385,8 @@ func TestParser_parseForSlice_CanSet(t *testing.T) {
 	parser.parseForSlice(v, "")
 }
 
-//mock multi-layer nested structure,
-//BenchmarkUnmarshal-4   	  208219	     14873 ns/op
+// mock multi-layer nested structure,
+// BenchmarkUnmarshal-4   	  208219	     14873 ns/op
 func BenchmarkUnmarshal(b *testing.B) {
 	var data = "Id=1&name=test&child[desc]=c1&child[Long]=10&childPtr[Long]=2&childPtr[Description]=b" +
 		"&children[0][desc]=d1&children[1][Long]=12&children[5][desc]=d5&children[5][Long]=50&desc=rtt" +


### PR DESCRIPTION
Fixed the issue where data was not assignable to the underlying type.

For example:

```go
type CustomType int

type MyStruct struct {
  Value CustomType `query:"val"`
}
```
Unmarshalling to this will panic with:
```
reflect.Set: value of type int is not assignable to type CustomType
```